### PR TITLE
Strongly-typed conditions from functions

### DIFF
--- a/core/src/main/java/io/doov/core/dsl/field/types/Condition.java
+++ b/core/src/main/java/io/doov/core/dsl/field/types/Condition.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Courtanet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.doov.core.dsl.field.types;
+
+import java.util.Optional;
+
+import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.lang.Context;
+import io.doov.core.dsl.lang.Readable;
+
+public interface Condition<T> extends Readable {
+
+    Optional<T> value(DslModel model, Context context);
+}

--- a/core/src/main/java/io/doov/core/dsl/field/types/DateIsoFieldInfo.java
+++ b/core/src/main/java/io/doov/core/dsl/field/types/DateIsoFieldInfo.java
@@ -12,21 +12,16 @@
  */
 package io.doov.core.dsl.field.types;
 
+import static io.doov.core.dsl.meta.LeafMetadata.fieldMetadata;
 import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE;
 
 import java.time.LocalDate;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
-import io.doov.core.FieldId;
 import io.doov.core.FieldInfo;
 import io.doov.core.dsl.DslField;
-import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.field.DelegatingFieldInfoImpl;
 import io.doov.core.dsl.impl.LocalDateCondition;
-import io.doov.core.dsl.impl.TemporalCondition;
-import io.doov.core.dsl.lang.Context;
-import io.doov.core.dsl.meta.PredicateMetadata;
 
 public class DateIsoFieldInfo extends DelegatingFieldInfoImpl implements TemporalFieldInfo<LocalDate> {
 
@@ -39,30 +34,12 @@ public class DateIsoFieldInfo extends DelegatingFieldInfoImpl implements Tempora
         return new DateIsoCondition(this);
     }
 
-    public static Optional<LocalDate> parse(DslModel model, FieldId id) {
-        return Optional.ofNullable(model.<String> get(id)).map(v -> LocalDate.parse(v, BASIC_ISO_DATE));
-    }
-
     private class DateIsoCondition extends LocalDateCondition {
 
         private DateIsoCondition(DslField field) {
-            super(field);
-        }
-
-        private DateIsoCondition(DslField field, PredicateMetadata metadata,
-                        BiFunction<DslModel, Context, Optional<LocalDate>> value) {
-            super(field, metadata, value);
-        }
-
-        @Override
-        protected TemporalCondition<LocalDate> temporalCondition(DslField field, PredicateMetadata metadata,
-                        BiFunction<DslModel, Context, Optional<LocalDate>> value) {
-            return new DateIsoCondition(field, metadata, value);
-        }
-
-        @Override
-        protected Optional<LocalDate> valueModel(DslModel model, DslField field) {
-            return parse(model, field.id());
+            super(fieldMetadata(field),
+                    ((model, context) -> Optional.ofNullable(model.<String> get(field.id()))
+                            .map(v -> LocalDate.parse(v, BASIC_ISO_DATE))));
         }
 
     }

--- a/core/src/main/java/io/doov/core/dsl/field/types/TimeIsoFieldInfo.java
+++ b/core/src/main/java/io/doov/core/dsl/field/types/TimeIsoFieldInfo.java
@@ -12,21 +12,16 @@
  */
 package io.doov.core.dsl.field.types;
 
+import static io.doov.core.dsl.meta.LeafMetadata.fieldMetadata;
 import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE;
 
 import java.time.LocalTime;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
-import io.doov.core.FieldId;
 import io.doov.core.FieldInfo;
 import io.doov.core.dsl.DslField;
-import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.field.DelegatingFieldInfoImpl;
 import io.doov.core.dsl.impl.LocalTimeCondition;
-import io.doov.core.dsl.impl.TemporalCondition;
-import io.doov.core.dsl.lang.Context;
-import io.doov.core.dsl.meta.PredicateMetadata;
 
 public class TimeIsoFieldInfo extends DelegatingFieldInfoImpl implements TemporalFieldInfo<LocalTime> {
 
@@ -39,30 +34,12 @@ public class TimeIsoFieldInfo extends DelegatingFieldInfoImpl implements Tempora
         return new TimeIsoCondition(this);
     }
 
-    public static Optional<LocalTime> parse(DslModel model, FieldId id) {
-        return Optional.ofNullable(model.<String> get(id)).map(v -> LocalTime.parse(v, BASIC_ISO_DATE));
-    }
-
     private class TimeIsoCondition extends LocalTimeCondition {
 
         private TimeIsoCondition(DslField field) {
-            super(field);
-        }
-
-        private TimeIsoCondition(DslField field, PredicateMetadata metadata,
-                        BiFunction<DslModel, Context, Optional<LocalTime>> value) {
-            super(field, metadata, value);
-        }
-
-        @Override
-        protected TemporalCondition<LocalTime> temporalCondition(DslField field, PredicateMetadata metadata,
-                        BiFunction<DslModel, Context, Optional<LocalTime>> value) {
-            return new TimeIsoCondition(field, metadata, value);
-        }
-
-        @Override
-        protected Optional<LocalTime> valueModel(DslModel model, DslField field) {
-            return parse(model, field.id());
+            super(fieldMetadata(field),
+                    ((model, context) -> Optional.ofNullable(model.<String>get(field.id()))
+                            .map(v -> LocalTime.parse(v, BASIC_ISO_DATE))));
         }
 
     }

--- a/core/src/main/java/io/doov/core/dsl/impl/AbstractCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/AbstractCondition.java
@@ -29,13 +29,11 @@ abstract class AbstractCondition<N> implements Readable {
 
     protected final DslField field;
     protected final PredicateMetadata metadata;
-    protected final BiFunction<DslModel, DslField, Optional<N>> value;
     protected final BiFunction<DslModel, Context, Optional<N>> function;
 
     protected AbstractCondition(DslField field) {
         this.field = field;
         this.metadata = fieldMetadata(field);
-        this.value = (model, context) -> valueModel(model, field);
         this.function = (model, context) -> valueModel(model, field);
     }
 
@@ -43,16 +41,15 @@ abstract class AbstractCondition<N> implements Readable {
             BiFunction<DslModel, Context, Optional<N>> function) {
         this.field = field;
         this.metadata = metadata;
-        this.value = (model, f) -> function.apply(model, null);
         this.function = function;
     }
 
     protected Optional<N> valueModel(DslModel model, DslField field) {
-        return Optional.ofNullable(model.<N> get(field.id()));
+        return Optional.ofNullable(model.get(field.id()));
     }
 
-    protected final Optional<N> value(DslModel model, DslField field) {
-        return value.apply(model, field);
+    protected final Optional<N> value(DslModel model, Context context) {
+        return function.apply(model, context);
     }
 
     protected final StepCondition predicate(LeafMetadata metadata,

--- a/core/src/main/java/io/doov/core/dsl/impl/AbstractCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/AbstractCondition.java
@@ -12,48 +12,37 @@
  */
 package io.doov.core.dsl.impl;
 
-import static io.doov.core.dsl.meta.LeafMetadata.fieldMetadata;
-
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import io.doov.core.dsl.DslField;
 import io.doov.core.dsl.DslModel;
+import io.doov.core.dsl.field.types.Condition;
 import io.doov.core.dsl.lang.Context;
-import io.doov.core.dsl.lang.Readable;
 import io.doov.core.dsl.lang.StepCondition;
-import io.doov.core.dsl.meta.*;
+import io.doov.core.dsl.meta.LeafMetadata;
+import io.doov.core.dsl.meta.PredicateMetadata;
 
-abstract class AbstractCondition<N> implements Readable {
+abstract class AbstractCondition<N> implements Condition<N> {
 
-    protected final DslField field;
+    static <T> Optional<T> valueModel(DslModel model, DslField<T> field) {
+        return Optional.ofNullable(model.get(field.id()));
+    }
+
     protected final PredicateMetadata metadata;
     protected final BiFunction<DslModel, Context, Optional<N>> function;
 
-    protected AbstractCondition(DslField field) {
-        this.field = field;
-        this.metadata = fieldMetadata(field);
-        this.function = (model, context) -> valueModel(model, field);
-    }
-
-    protected AbstractCondition(DslField field, PredicateMetadata metadata,
-            BiFunction<DslModel, Context, Optional<N>> function) {
-        this.field = field;
+    protected AbstractCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<N>> function) {
         this.metadata = metadata;
         this.function = function;
     }
 
-    protected Optional<N> valueModel(DslModel model, DslField field) {
-        return Optional.ofNullable(model.get(field.id()));
-    }
-
-    protected final Optional<N> value(DslModel model, Context context) {
+    public Optional<N> value(DslModel model, Context context) {
         return function.apply(model, context);
     }
 
-    protected final StepCondition predicate(LeafMetadata metadata,
-            Function<N, Boolean> predicate) {
+    protected final StepCondition predicate(LeafMetadata metadata, Function<N, Boolean> predicate) {
         return new PredicateStepCondition<>(this.metadata.merge(metadata), function, predicate);
     }
 

--- a/core/src/main/java/io/doov/core/dsl/impl/BooleanCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/BooleanCondition.java
@@ -34,13 +34,12 @@ import io.doov.core.dsl.meta.LeafMetadata;
  */
 public class BooleanCondition extends DefaultCondition<Boolean> {
 
-    public BooleanCondition(DslField field) {
+    public BooleanCondition(DslField<Boolean> field) {
         super(field);
     }
 
-    public BooleanCondition(DslField field, LeafMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<Boolean>> value) {
-        super(field, metadata, value);
+    public BooleanCondition(LeafMetadata metadata, BiFunction<DslModel, Context, Optional<Boolean>> value) {
+        super(metadata, value);
     }
 
     /**
@@ -49,7 +48,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition not() {
-        return predicate(notMetadata(field), value -> !value);
+        return predicate(notMetadata(metadata), value -> !value);
     }
 
     /**
@@ -59,7 +58,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition and(boolean value) {
-        return predicate(andMetadata(field, value),
+        return predicate(andMetadata(metadata, value),
                         (model, context) -> Optional.of(value),
                         Boolean::logicalAnd);
     }
@@ -71,7 +70,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition and(LogicalFieldInfo value) {
-        return predicate(andMetadata(field, value),
+        return predicate(andMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         Boolean::logicalAnd);
     }
@@ -83,7 +82,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition or(boolean value) {
-        return predicate(orMetadata(field, value),
+        return predicate(orMetadata(metadata, value),
                         (model, context) -> Optional.of(value),
                         Boolean::logicalOr);
     }
@@ -95,7 +94,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition or(LogicalFieldInfo value) {
-        return predicate(orMetadata(field, value),
+        return predicate(orMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         Boolean::logicalOr);
     }
@@ -107,7 +106,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition xor(boolean value) {
-        return predicate(xorMetadata(field, value),
+        return predicate(xorMetadata(metadata, value),
                         (model, context) -> Optional.of(value),
                         Boolean::logicalXor);
     }
@@ -119,7 +118,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition xor(LogicalFieldInfo value) {
-        return predicate(xorMetadata(field, value),
+        return predicate(xorMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         Boolean::logicalXor);
     }
@@ -130,7 +129,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition isTrue() {
-        return predicate(isMetadata(field, true),
+        return predicate(isMetadata(metadata, true),
                         (model, context) -> Optional.of(TRUE),
                         Boolean::equals);
     }
@@ -141,7 +140,7 @@ public class BooleanCondition extends DefaultCondition<Boolean> {
      * @return the step condition
      */
     public final StepCondition isFalse() {
-        return predicate(isMetadata(field, false),
+        return predicate(isMetadata(metadata, false),
                         (model, context) -> Optional.of(FALSE),
                         Boolean::equals);
     }

--- a/core/src/main/java/io/doov/core/dsl/impl/DefaultCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/DefaultCondition.java
@@ -38,13 +38,12 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class DefaultCondition<T> extends AbstractCondition<T> {
 
-    public DefaultCondition(DslField field) {
-        super(field);
+    public DefaultCondition(DslField<T> field) {
+        this(fieldMetadata(field), (model, context) -> valueModel(model, field));
     }
 
-    public DefaultCondition(DslField field, PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<T>>
-                    value) {
-        super(field, metadata, value);
+    public DefaultCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<T>> value) {
+        super(metadata, value);
     }
 
     /**
@@ -53,9 +52,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition isNull() {
-        return new PredicateStepCondition<>(metadata.merge(nullMetadata(field)),
-                        (model, context) -> Optional.of(function.apply(model, context)),
-                        optional -> !optional.isPresent());
+        return new PredicateStepCondition<>(nullMetadata(metadata),
+                (model, context) -> Optional.of(value(model, context)),
+                optional -> !optional.isPresent());
     }
 
     /**
@@ -64,9 +63,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition isNotNull() {
-        return new PredicateStepCondition<>(metadata.merge(notNullMetadata(field)),
-                        (model, context) -> Optional.of(function.apply(model, context)),
-                        Optional::isPresent);
+        return new PredicateStepCondition<>(notNullMetadata(metadata),
+                (model, context) -> Optional.of(value(model, context)),
+                Optional::isPresent);
     }
 
     /**
@@ -76,9 +75,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition eq(T value) {
-        return predicate(equalsMetadata(field, value),
-                        (model, context) -> Optional.ofNullable(value),
-                        Object::equals);
+        return predicate(equalsMetadata(metadata, value),
+                (model, context) -> Optional.ofNullable(value),
+                Object::equals);
     }
 
     /**
@@ -88,9 +87,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition eq(Supplier<T> value) {
-        return predicate(equalsMetadata(field, value),
-                        (model, context) -> Optional.ofNullable(value.get()),
-                        Object::equals);
+        return predicate(equalsMetadata(metadata, value),
+                (model, context) -> Optional.ofNullable(value.get()),
+                Object::equals);
     }
 
     /**
@@ -100,9 +99,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition eq(BaseFieldInfo<T> value) {
-        return predicate(equalsMetadata(field, value),
-                        (model, context) -> valueModel(model, value),
-                        Object::equals);
+        return predicate(equalsMetadata(metadata, value),
+                (model, context) -> valueModel(model, value),
+                Object::equals);
     }
 
     /**
@@ -112,9 +111,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition eq(DefaultCondition<T> value) {
-        return predicate(equalsMetadata(field, value),
-                        value.function,
-                        Object::equals);
+        return predicate(equalsMetadata(metadata, value),
+                value.function,
+                Object::equals);
     }
 
     /**
@@ -124,9 +123,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition notEq(T value) {
-        return predicate(notEqualsMetadata(field, value),
-                        (model, context) -> Optional.ofNullable(value),
-                        (l, r) -> !l.equals(r));
+        return predicate(notEqualsMetadata(metadata, value),
+                (model, context) -> Optional.ofNullable(value),
+                (l, r) -> !l.equals(r));
     }
 
     /**
@@ -136,9 +135,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition notEq(Supplier<T> value) {
-        return predicate(notEqualsMetadata(field, value),
-                        (model, context) -> Optional.ofNullable(value.get()),
-                        (l, r) -> !l.equals(r));
+        return predicate(notEqualsMetadata(metadata, value),
+                (model, context) -> Optional.ofNullable(value.get()),
+                (l, r) -> !l.equals(r));
     }
 
     /**
@@ -148,9 +147,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition notEq(BaseFieldInfo<T> value) {
-        return predicate(notEqualsMetadata(field, value),
-                        (model, context) -> valueModel(model, value),
-                        (l, r) -> !l.equals(r));
+        return predicate(notEqualsMetadata(metadata, value),
+                (model, context) -> valueModel(model, value),
+                (l, r) -> !l.equals(r));
     }
 
     /**
@@ -160,9 +159,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition notEq(DefaultCondition<T> value) {
-        return predicate(notEqualsMetadata(field, value),
-                        value.function,
-                        (l, r) -> !l.equals(r));
+        return predicate(notEqualsMetadata(metadata, value),
+                value.function,
+                (l, r) -> !l.equals(r));
     }
 
     /**
@@ -173,8 +172,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      */
     @SafeVarargs
     public final StepCondition anyMatch(T... values) {
-        return predicate(matchAnyMetadata(field, asList(values)),
-                        value -> Arrays.stream(values).anyMatch(value::equals));
+        return predicate(matchAnyMetadata(metadata, asList(values)),
+                value -> Arrays.stream(values).anyMatch(value::equals));
     }
 
     /**
@@ -184,8 +183,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition anyMatch(Collection<T> values) {
-        return predicate(matchAnyMetadata(field, values),
-                        value -> values.stream().anyMatch(value::equals));
+        return predicate(matchAnyMetadata(metadata, values),
+                value -> values.stream().anyMatch(value::equals));
     }
 
     /**
@@ -195,8 +194,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition anyMatch(List<Predicate<T>> values) {
-        return predicate(matchAnyMetadata(field),
-                        value -> values.stream().anyMatch(v -> v.test(value)));
+        return predicate(matchAnyMetadata(metadata),
+                value -> values.stream().anyMatch(v -> v.test(value)));
     }
 
     /**
@@ -207,8 +206,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      */
     @SafeVarargs
     public final StepCondition allMatch(T... values) {
-        return predicate(matchAllMetadata(field, asList(values)),
-                        value -> Arrays.stream(values).allMatch(value::equals));
+        return predicate(matchAllMetadata(metadata, asList(values)),
+                value -> Arrays.stream(values).allMatch(value::equals));
     }
 
     /**
@@ -218,8 +217,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition allMatch(Collection<T> values) {
-        return predicate(matchAllMetadata(field, values),
-                        value -> values.stream().allMatch(value::equals));
+        return predicate(matchAllMetadata(metadata, values),
+                value -> values.stream().allMatch(value::equals));
     }
 
     /**
@@ -229,8 +228,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition allMatch(List<Predicate<T>> values) {
-        return predicate(matchAllMetadata(field),
-                        value -> values.stream().allMatch(v -> v.test(value)));
+        return predicate(matchAllMetadata(metadata),
+                value -> values.stream().allMatch(v -> v.test(value)));
     }
 
     /**
@@ -241,8 +240,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      */
     @SafeVarargs
     public final StepCondition noneMatch(T... values) {
-        return predicate(matchNoneMetadata(field, asList(values)),
-                        value -> Arrays.stream(values).noneMatch(value::equals));
+        return predicate(matchNoneMetadata(metadata, asList(values)),
+                value -> Arrays.stream(values).noneMatch(value::equals));
     }
 
     /**
@@ -252,8 +251,8 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition noneMatch(Collection<T> values) {
-        return predicate(matchNoneMetadata(field, values),
-                        value -> values.stream().noneMatch(value::equals));
+        return predicate(matchNoneMetadata(metadata, values),
+                value -> values.stream().noneMatch(value::equals));
     }
 
     /**
@@ -263,10 +262,9 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the step condition
      */
     public final StepCondition noneMatch(List<Predicate<T>> values) {
-        return predicate(matchNoneMetadata(field),
-                        value -> values.stream().noneMatch(v -> v.test(value)));
+        return predicate(matchNoneMetadata(metadata),
+                value -> values.stream().noneMatch(v -> v.test(value)));
     }
-
     /**
      * Returns an integer step condition that returns the node value mapped by the given mapper.
      *
@@ -274,8 +272,7 @@ public class DefaultCondition<T> extends AbstractCondition<T> {
      * @return the integer condition
      */
     public final IntegerCondition mapToInt(Function<T, Integer> mapper) {
-        return new IntegerCondition(field, mapToIntMetadata(field),
-                        (model, context) -> function.apply(model, context).map(mapper));
+        return new IntegerCondition(mapToIntMetadata(metadata), (model, context) -> value(model, context).map(mapper));
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/impl/DoubleCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/DoubleCondition.java
@@ -26,19 +26,19 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class DoubleCondition extends NumericCondition<Double> {
 
-    public DoubleCondition(DslField field) {
+    public DoubleCondition(DslField<Double> field) {
         super(field);
     }
 
-    public DoubleCondition(DslField field, PredicateMetadata metadata,
+    public DoubleCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<Double>> value) {
-        super(field, metadata, value);
+        super(metadata, value);
     }
 
     @Override
-    protected NumericCondition<Double> numericCondition(DslField field, PredicateMetadata metadata,
+    protected NumericCondition<Double> numericCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<Double>> value) {
-        return new DoubleCondition(field, metadata, value);
+        return new DoubleCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/FloatCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/FloatCondition.java
@@ -26,19 +26,18 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class FloatCondition extends NumericCondition<Float> {
 
-    public FloatCondition(DslField field) {
+    public FloatCondition(DslField<Float> field) {
         super(field);
     }
 
-    public FloatCondition(DslField field, PredicateMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<Float>> value) {
-        super(field, metadata, value);
+    public FloatCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<Float>> value) {
+        super(metadata, value);
     }
 
     @Override
-    protected NumericCondition<Float> numericCondition(DslField field, PredicateMetadata metadata,
+    protected NumericCondition<Float> numericCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<Float>> value) {
-        return new FloatCondition(field, metadata, value);
+        return new FloatCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/IntegerCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/IntegerCondition.java
@@ -26,24 +26,22 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class IntegerCondition extends NumericCondition<Integer> {
 
-    public IntegerCondition(DslField field) {
+    public IntegerCondition(DslField<Integer> field) {
         super(field);
     }
 
-    public IntegerCondition(DslField field, PredicateMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<Integer>> value) {
-        super(field, metadata, value);
+    public IntegerCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<Integer>> value) {
+        super(metadata, value);
     }
 
     public IntegerCondition(NumericCondition<Long> condition) {
-        super(condition.field, condition.metadata,
-                        (model, context) -> condition.function.apply(model, context).map(Long::intValue));
+        this(condition.metadata, (model, context) -> condition.function.apply(model, context).map(Long::intValue));
     }
 
     @Override
-    protected NumericCondition<Integer> numericCondition(DslField field, PredicateMetadata metadata,
+    protected NumericCondition<Integer> numericCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<Integer>> value) {
-        return new IntegerCondition(field, metadata, value);
+        return new IntegerCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/IterableCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/IterableCondition.java
@@ -19,42 +19,42 @@ import io.doov.core.dsl.meta.LeafMetadata;
 
 public class IterableCondition<T, C extends Iterable<T>> extends DefaultCondition<C> {
 
-    public IterableCondition(DslField field) {
+    public IterableCondition(DslField<C> field) {
         super(field);
     }
 
-    public IterableCondition(DslField field, LeafMetadata metadata, BiFunction<DslModel, Context, Optional<C>> value) {
-        super(field, metadata, value);
+    public IterableCondition(LeafMetadata metadata, BiFunction<DslModel, Context, Optional<C>> value) {
+        super(metadata, value);
     }
 
     public StepCondition contains(T value) {
-        return predicate(containsMetadata(field, value),
+        return predicate(containsMetadata(metadata, value),
                 collection -> stream(collection.spliterator(), false)
                         .anyMatch(value::equals));
     }
 
     @SafeVarargs
     public final StepCondition containsAll(T... values) {
-        return predicate(containsMetadata(field, (Object[]) values),
+        return predicate(containsMetadata(metadata, (Object[]) values),
                 iterable -> stream(iterable.spliterator(), false)
                         .collect(toSet()).containsAll(asList(values)));
     }
 
     public StepCondition isEmpty() {
-        return predicate(isEmptyMetadata(field), iterable -> !iterable.iterator().hasNext());
+        return predicate(isEmptyMetadata(metadata), iterable -> !iterable.iterator().hasNext());
     }
 
     public StepCondition isNotEmpty() {
-        return predicate(isNotEmptyMetadata(field), iterable -> iterable.iterator().hasNext());
+        return predicate(isNotEmptyMetadata(metadata), iterable -> iterable.iterator().hasNext());
     }
 
     public StepCondition hasSize(int size) {
-        return predicate(hasSizeMetadata(field, size),
+        return predicate(hasSizeMetadata(metadata, size),
                 iterable -> stream(iterable.spliterator(), false).count() == size);
     }
 
     public StepCondition hasNotSize(int size) {
-        return predicate(hasNotSizeMetadata(field, size),
+        return predicate(hasNotSizeMetadata(metadata, size),
                 iterable -> stream(iterable.spliterator(), false).count() != size);
     }
 

--- a/core/src/main/java/io/doov/core/dsl/impl/LocalDateCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/LocalDateCondition.java
@@ -31,19 +31,18 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class LocalDateCondition extends TemporalCondition<LocalDate> {
 
-    public LocalDateCondition(DslField field) {
+    public LocalDateCondition(DslField<LocalDate> field) {
         super(field);
     }
 
-    public LocalDateCondition(DslField field, PredicateMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<LocalDate>> value) {
-        super(field, metadata, value);
+    public LocalDateCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<LocalDate>> value) {
+        super(metadata, value);
     }
 
     @Override
-    protected TemporalCondition<LocalDate> temporalCondition(DslField field, PredicateMetadata metadata,
+    protected TemporalCondition<LocalDate> temporalCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<LocalDate>> value) {
-        return new LocalDateCondition(field, metadata, value);
+        return new LocalDateCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/LocalDateTimeCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/LocalDateTimeCondition.java
@@ -28,19 +28,19 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class LocalDateTimeCondition extends TemporalCondition<LocalDateTime> {
 
-    public LocalDateTimeCondition(DslField field) {
+    public LocalDateTimeCondition(DslField<LocalDateTime> field) {
         super(field);
     }
 
-    public LocalDateTimeCondition(DslField field, PredicateMetadata metadata,
+    public LocalDateTimeCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<LocalDateTime>> value) {
-        super(field, metadata, value);
+        super(metadata, value);
     }
 
     @Override
-    protected TemporalCondition<LocalDateTime> temporalCondition(DslField field, PredicateMetadata metadata,
+    protected TemporalCondition<LocalDateTime> temporalCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<LocalDateTime>> value) {
-        return new LocalDateTimeCondition(field, metadata, value);
+        return new LocalDateTimeCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/LocalTimeCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/LocalTimeCondition.java
@@ -28,19 +28,19 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class LocalTimeCondition extends TemporalCondition<LocalTime> {
 
-    public LocalTimeCondition(DslField field) {
+    public LocalTimeCondition(DslField<LocalTime> field) {
         super(field);
     }
 
-    public LocalTimeCondition(DslField field, PredicateMetadata metadata,
+    public LocalTimeCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<LocalTime>> value) {
-        super(field, metadata, value);
+        super(metadata, value);
     }
 
     @Override
-    protected TemporalCondition<LocalTime> temporalCondition(DslField field, PredicateMetadata metadata,
+    protected TemporalCondition<LocalTime> temporalCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<LocalTime>> value) {
-        return new LocalTimeCondition(field, metadata, value);
+        return new LocalTimeCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/LogicalNaryCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/LogicalNaryCondition.java
@@ -50,7 +50,7 @@ public class LogicalNaryCondition extends AbstractStepCondition {
      * @return the integer condition
      */
     public static IntegerCondition count(List<StepCondition> steps) {
-        return new IntegerCondition(null, countMetadata(getMetadatas(steps)),
+        return new IntegerCondition(countMetadata(getMetadatas(steps)),
                         (model, context) -> Optional.of((int) steps.stream()
                                         .filter(s -> s.predicate().test(model, context))
                                         .count()));

--- a/core/src/main/java/io/doov/core/dsl/impl/LongCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/LongCondition.java
@@ -26,19 +26,18 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public class LongCondition extends NumericCondition<Long> {
 
-    public LongCondition(DslField field) {
+    public LongCondition(DslField<Long> field) {
         super(field);
     }
 
-    public LongCondition(DslField field, PredicateMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<Long>> value) {
-        super(field, metadata, value);
+    public LongCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<Long>> value) {
+        super(metadata, value);
     }
 
     @Override
-    protected NumericCondition<Long> numericCondition(DslField field, PredicateMetadata metadata,
+    protected NumericCondition<Long> numericCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<Long>> value) {
-        return new LongCondition(field, metadata, value);
+        return new LongCondition(metadata, value);
     }
 
     @Override

--- a/core/src/main/java/io/doov/core/dsl/impl/NumericCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/NumericCondition.java
@@ -41,15 +41,15 @@ import io.doov.core.dsl.meta.PredicateMetadata;
  */
 public abstract class NumericCondition<N extends Number> extends DefaultCondition<N> {
 
-    NumericCondition(DslField field) {
+    NumericCondition(DslField<N> field) {
         super(field);
     }
 
-    NumericCondition(DslField field, PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<N>> value) {
-        super(field, metadata, value);
+    NumericCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<N>> value) {
+        super(metadata, value);
     }
 
-    protected abstract NumericCondition<N> numericCondition(DslField field, PredicateMetadata metadata,
+    protected abstract NumericCondition<N> numericCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<N>> value);
 
     /**
@@ -59,7 +59,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition lesserThan(N value) {
-        return predicate(lesserThanMetadata(field, value),
+        return predicate(lesserThanMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         (l, r) -> lesserThanFunction().apply(l, r));
     }
@@ -71,7 +71,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition lesserThan(NumericFieldInfo<N> value) {
-        return predicate(lesserThanMetadata(field, value),
+        return predicate(lesserThanMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         (l, r) -> lesserThanFunction().apply(l, r));
     }
@@ -83,7 +83,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition lesserOrEquals(N value) {
-        return predicate(lesserOrEqualsMetadata(field, value),
+        return predicate(lesserOrEqualsMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         (l, r) -> lesserOrEqualsFunction().apply(l, r));
     }
@@ -95,7 +95,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition lesserOrEquals(NumericFieldInfo<N> value) {
-        return predicate(lesserOrEqualsMetadata(field, value),
+        return predicate(lesserOrEqualsMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         (l, r) -> lesserOrEqualsFunction().apply(l, r));
     }
@@ -111,7 +111,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition greaterThan(N value) {
-        return predicate(greaterThanMetadata(field, value),
+        return predicate(greaterThanMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         (l, r) -> greaterThanFunction().apply(l, r));
     }
@@ -123,7 +123,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition greaterThan(NumericFieldInfo<N> value) {
-        return predicate(greaterThanMetadata(field, value),
+        return predicate(greaterThanMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         (l, r) -> greaterThanFunction().apply(l, r));
     }
@@ -135,7 +135,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition greaterOrEquals(N value) {
-        return predicate(greaterOrEqualsMetadata(field, value),
+        return predicate(greaterOrEqualsMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         (l, r) -> greaterOrEqualsFunction().apply(l, r));
     }
@@ -147,7 +147,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the step condition
      */
     public final StepCondition greaterOrEquals(NumericFieldInfo<N> value) {
-        return predicate(greaterOrEqualsMetadata(field, value),
+        return predicate(greaterOrEqualsMetadata(metadata, value),
                         (model, context) -> valueModel(model, value),
                         (l, r) -> greaterOrEqualsFunction().apply(l, r));
     }
@@ -187,7 +187,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the numeric condition
      */
     public final NumericCondition<N> min(List<NumericFieldInfo<N>> fields) {
-        return numericCondition(null, minMetadata(getMetadataForFields(fields)),
+        return numericCondition(minMetadata(getMetadataForFields(fields)),
                         (model, context) -> fields.stream()
                                         .map(f -> Optional.ofNullable(model.<N> get(f.id())))
                                         .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
@@ -203,7 +203,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the numeric condition
      */
     public final NumericCondition<N> sum(List<NumericFieldInfo<N>> fields) {
-        return numericCondition(null, sumMetadata(getMetadataForFields(fields)),
+        return numericCondition(sumMetadata(getMetadataForFields(fields)),
                         (model, context) -> Optional.of(fields.stream()
                                         .map(f -> Optional.ofNullable(model.<N> get(f.id())))
                                         .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
@@ -217,7 +217,7 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the numeric condition
      */
     public final NumericCondition<N> sumConditions(List<NumericCondition<N>> conditions) {
-        return numericCondition(null, sumMetadata(getMetadataForConditions(conditions)),
+        return numericCondition(sumMetadata(getMetadataForConditions(conditions)),
                         (model, context) -> Optional.of(conditions.stream()
                                         .map(c -> c.function.apply(model, context))
                                         .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
@@ -233,8 +233,8 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the numeric condition
      */
     public final NumericCondition<N> times(int multiplier) {
-        return numericCondition(field, timesMetadata(field, multiplier),
-                        (model, context) -> valueModel(model, field)
+        return numericCondition(timesMetadata(metadata, multiplier),
+                        (model, context) -> value(model, context)
                                         .map(v -> timesFunction().apply(v, multiplier)));
     }
 
@@ -247,9 +247,9 @@ public abstract class NumericCondition<N extends Number> extends DefaultConditio
      * @return the numeric condition
      */
     public final NumericCondition<N> when(StepCondition condition) {
-        return numericCondition(field, whenMetadata(field, condition),
+        return numericCondition(whenMetadata(metadata, condition),
                         (model, context) -> condition.predicate().test(model, context)
-                                        ? valueModel(model, field)
+                                        ? value(model, context)
                                         : Optional.empty());
     }
 

--- a/core/src/main/java/io/doov/core/dsl/impl/StringCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/StringCondition.java
@@ -22,6 +22,7 @@ import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.lang.Context;
 import io.doov.core.dsl.lang.StepCondition;
 import io.doov.core.dsl.meta.LeafMetadata;
+import io.doov.core.dsl.meta.PredicateMetadata;
 
 /**
  * Base class for string conditions.
@@ -31,13 +32,12 @@ import io.doov.core.dsl.meta.LeafMetadata;
  */
 public class StringCondition extends DefaultCondition<String> {
 
-    public StringCondition(DslField field) {
+    public StringCondition(DslField<String> field) {
         super(field);
     }
 
-    public StringCondition(DslField field, LeafMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<String>> value) {
-        super(field, metadata, value);
+    public StringCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<String>> value) {
+        super(metadata, value);
     }
 
     /**
@@ -47,7 +47,7 @@ public class StringCondition extends DefaultCondition<String> {
      * @return the step condition
      */
     public final StepCondition contains(String value) {
-        return predicate(containsMetadata(field, value),
+        return predicate(containsMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         String::contains);
     }
@@ -59,7 +59,7 @@ public class StringCondition extends DefaultCondition<String> {
      * @return the step condition
      */
     public final StepCondition matches(String value) {
-        return predicate(matchesMetadata(field, value),
+        return predicate(matchesMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         String::matches);
     }
@@ -71,7 +71,7 @@ public class StringCondition extends DefaultCondition<String> {
      * @return the step condition
      */
     public final StepCondition startsWith(String value) {
-        return predicate(startsWithMetadata(field, value),
+        return predicate(startsWithMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         String::startsWith);
     }
@@ -83,7 +83,7 @@ public class StringCondition extends DefaultCondition<String> {
      * @return the step condition
      */
     public final StepCondition endsWith(String value) {
-        return predicate(endsWithMetadata(field, value),
+        return predicate(endsWithMetadata(metadata, value),
                         (model, context) -> Optional.ofNullable(value),
                         String::endsWith);
     }
@@ -94,9 +94,8 @@ public class StringCondition extends DefaultCondition<String> {
      * @return the integer condition
      */
     public IntegerCondition length() {
-        return new IntegerCondition(field, lengthIsMetadata(field),
-                        (model, context) -> Optional.ofNullable(model.<String> get(field.id()))
-                                        .map(String::length));
+        return new IntegerCondition(lengthIsMetadata(metadata),
+                        (model, context) -> value(model, context).map(String::length));
     }
 
     /**
@@ -105,9 +104,8 @@ public class StringCondition extends DefaultCondition<String> {
      * @return the integer condition
      */
     public IntegerCondition parseInt() {
-        return new IntegerCondition(field, fieldMetadata(field),
-                        (model, context) -> Optional.ofNullable(model.<String> get(field.id()))
-                                        .map(Integer::parseInt));
+        return new IntegerCondition(metadata,
+                        (model, context) -> value(model, context).map(Integer::parseInt));
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/impl/TemporalCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/TemporalCondition.java
@@ -60,7 +60,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      */
     public final TemporalCondition<N> with(TemporalAdjuster adjuster) {
         return temporalCondition(field, metadata.merge(withMetadata(field, adjuster.getMetadata())),
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .map(v -> withFunction(adjuster.getAdjuster()).apply(v)));
     }
 
@@ -75,7 +75,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      */
     public final TemporalCondition<N> minus(int value, TemporalUnit unit) {
         return temporalCondition(field, metadata.merge(minusMetadata(field, value, unit)),
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .map(v -> minusFunction(value, unit).apply(v)));
     }
 
@@ -88,7 +88,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      */
     public final TemporalCondition<N> minus(NumericFieldInfo<Integer> value, TemporalUnit unit) {
         return temporalCondition(field, metadata.merge(minusMetadata(field, value, unit)),
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(model.<Integer> get(value.id()))
                                                         .map(r -> minusFunction(r, unit).apply(l))));
     }
@@ -104,7 +104,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      */
     public final TemporalCondition<N> plus(int value, TemporalUnit unit) {
         return temporalCondition(field, metadata.merge(plusMetadata(field, value, unit)),
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .map(v -> plusFunction(value, unit).apply(v)));
     }
 
@@ -117,7 +117,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      */
     public final TemporalCondition<N> plus(NumericFieldInfo<Integer> value, TemporalUnit unit) {
         return temporalCondition(field, metadata.merge(plusMetadata(field, value, unit)),
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(model.<Integer> get(value.id()))
                                                         .map(r -> plusFunction(r, unit).apply(l))));
     }
@@ -155,8 +155,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the step condition
      */
     public final StepCondition before(TemporalFieldInfo<N> value) {
-        return predicate(beforeTemporalFieldMetadata(this, value),
-                        (model, context) -> value(model, value),
+        return predicate(beforeTemporalFieldMetadata(this, value), this::value,
                         (l, r) -> beforeFunction().apply(l, r));
     }
 
@@ -243,8 +242,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the step condition
      */
     public final StepCondition after(TemporalFieldInfo<N> value) {
-        return predicate(afterTemporalFieldMetadata(this, value),
-                        (model, context) -> value(model, value),
+        return predicate(afterTemporalFieldMetadata(this, value), this::value,
                         (l, r) -> afterFunction().apply(l, r));
     }
 
@@ -544,7 +542,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
 
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit, N value) {
         return new LongCondition(field, metadata,
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(value)
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
     }
@@ -552,7 +550,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit,
                     TemporalFieldInfo<N> value) {
         return new LongCondition(field, metadata,
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .flatMap(l -> valueModel(model, value)
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
     }
@@ -560,14 +558,14 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit,
                     TemporalCondition<N> value) {
         return new LongCondition(field, metadata,
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .flatMap(l -> value.function.apply(model, context)
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
     }
 
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit, Supplier<N> value) {
         return new LongCondition(field, metadata,
-                        (model, context) -> value(model, field)
+                        (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(value.get())
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
     }

--- a/core/src/main/java/io/doov/core/dsl/impl/TemporalCondition.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/TemporalCondition.java
@@ -40,16 +40,15 @@ import io.doov.core.dsl.time.TemporalAdjuster;
  */
 public abstract class TemporalCondition<N extends Temporal> extends DefaultCondition<N> {
 
-    public TemporalCondition(DslField field) {
+    public TemporalCondition(DslField<N> field) {
         super(field);
     }
 
-    public TemporalCondition(DslField field, PredicateMetadata metadata,
-                    BiFunction<DslModel, Context, Optional<N>> value) {
-        super(field, metadata, value);
+    public TemporalCondition(PredicateMetadata metadata, BiFunction<DslModel, Context, Optional<N>> value) {
+        super(metadata, value);
     }
 
-    abstract TemporalCondition<N> temporalCondition(DslField field, PredicateMetadata metadata,
+    abstract TemporalCondition<N> temporalCondition(PredicateMetadata metadata,
                     BiFunction<DslModel, Context, Optional<N>> value);
 
     /**
@@ -59,7 +58,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the temporal condition
      */
     public final TemporalCondition<N> with(TemporalAdjuster adjuster) {
-        return temporalCondition(field, metadata.merge(withMetadata(field, adjuster.getMetadata())),
+        return temporalCondition(metadata.merge(withMetadata(metadata, adjuster.getMetadata())),
                         (model, context) -> value(model, context)
                                         .map(v -> withFunction(adjuster.getAdjuster()).apply(v)));
     }
@@ -74,7 +73,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the temporal condition
      */
     public final TemporalCondition<N> minus(int value, TemporalUnit unit) {
-        return temporalCondition(field, metadata.merge(minusMetadata(field, value, unit)),
+        return temporalCondition(metadata.merge(minusMetadata(metadata, value, unit)),
                         (model, context) -> value(model, context)
                                         .map(v -> minusFunction(value, unit).apply(v)));
     }
@@ -87,7 +86,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the temporal condition
      */
     public final TemporalCondition<N> minus(NumericFieldInfo<Integer> value, TemporalUnit unit) {
-        return temporalCondition(field, metadata.merge(minusMetadata(field, value, unit)),
+        return temporalCondition(metadata.merge(minusMetadata(metadata, value, unit)),
                         (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(model.<Integer> get(value.id()))
                                                         .map(r -> minusFunction(r, unit).apply(l))));
@@ -103,7 +102,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the temporal condition
      */
     public final TemporalCondition<N> plus(int value, TemporalUnit unit) {
-        return temporalCondition(field, metadata.merge(plusMetadata(field, value, unit)),
+        return temporalCondition(metadata.merge(plusMetadata(metadata, value, unit)),
                         (model, context) -> value(model, context)
                                         .map(v -> plusFunction(value, unit).apply(v)));
     }
@@ -116,7 +115,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the temporal condition
      */
     public final TemporalCondition<N> plus(NumericFieldInfo<Integer> value, TemporalUnit unit) {
-        return temporalCondition(field, metadata.merge(plusMetadata(field, value, unit)),
+        return temporalCondition(metadata.merge(plusMetadata(metadata, value, unit)),
                         (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(model.<Integer> get(value.id()))
                                                         .map(r -> plusFunction(r, unit).apply(l))));
@@ -131,7 +130,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
      * @return the step condition
      */
     public final StepCondition eq(TemporalCondition<N> value) {
-        return predicate(equalsMetadata(field, value),
+        return predicate(equalsMetadata(metadata, value),
                         value.function,
                         Object::equals);
     }
@@ -541,7 +540,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
     }
 
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit, N value) {
-        return new LongCondition(field, metadata,
+        return new LongCondition(metadata,
                         (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(value)
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
@@ -549,7 +548,7 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
 
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit,
                     TemporalFieldInfo<N> value) {
-        return new LongCondition(field, metadata,
+        return new LongCondition(metadata,
                         (model, context) -> value(model, context)
                                         .flatMap(l -> valueModel(model, value)
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
@@ -557,14 +556,14 @@ public abstract class TemporalCondition<N extends Temporal> extends DefaultCondi
 
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit,
                     TemporalCondition<N> value) {
-        return new LongCondition(field, metadata,
+        return new LongCondition(metadata,
                         (model, context) -> value(model, context)
                                         .flatMap(l -> value.function.apply(model, context)
                                                         .map(r -> betweenFunction(unit).apply(l, r))));
     }
 
     private NumericCondition<Long> timeBetween(PredicateMetadata metadata, ChronoUnit unit, Supplier<N> value) {
-        return new LongCondition(field, metadata,
+        return new LongCondition(metadata,
                         (model, context) -> value(model, context)
                                         .flatMap(l -> Optional.ofNullable(value.get())
                                                         .map(r -> betweenFunction(unit).apply(l, r))));

--- a/core/src/main/java/io/doov/core/dsl/meta/LeafMetadata.java
+++ b/core/src/main/java/io/doov/core/dsl/meta/LeafMetadata.java
@@ -76,7 +76,7 @@ public class LeafMetadata extends PredicateMetadata {
 
     @Override
     public List<Element> flatten() {
-        return elements.stream().collect(toList());
+        return new ArrayList<>(elements);
     }
 
     private static MetadataType mergeType(MetadataType current, MetadataType merged) {

--- a/core/src/main/java/io/doov/core/dsl/meta/LeafMetadata.java
+++ b/core/src/main/java/io/doov/core/dsl/meta/LeafMetadata.java
@@ -49,6 +49,14 @@ public class LeafMetadata extends PredicateMetadata {
         this.type = type;
     }
 
+    public LeafMetadata(PredicateMetadata metadata) {
+        this(new ArrayDeque<>(metadata.flatten()), metadata.type());
+    }
+
+    public LeafMetadata(PredicateMetadata metadata, MetadataType type) {
+        this(new ArrayDeque<>(metadata.flatten()), type);
+    }
+
     private LeafMetadata(Deque<Element> elements, MetadataType type) {
         this.elements = elements;
         this.type = type;
@@ -221,14 +229,14 @@ public class LeafMetadata extends PredicateMetadata {
 
     // times
 
-    public static LeafMetadata timesMetadata(DslField field, int multiplier) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(times).valueObject(multiplier);
+    public static LeafMetadata timesMetadata(PredicateMetadata metadata, int multiplier) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(times).valueObject(multiplier);
     }
 
     // when
 
-    public static LeafMetadata whenMetadata(DslField field, StepCondition condition) {
-        final LeafMetadata exp = new LeafMetadata(FIELD_PREDICATE).field(field).operator(when);
+    public static LeafMetadata whenMetadata(PredicateMetadata metadata, StepCondition condition) {
+        final LeafMetadata exp = new LeafMetadata(metadata, FIELD_PREDICATE).operator(when);
         exp.elements.add(leftParenthesis());
         exp.elements.addAll(condition.getMetadata().flatten());
         exp.elements.add(rightParenthesis());
@@ -237,92 +245,92 @@ public class LeafMetadata extends PredicateMetadata {
 
     // equals
 
-    public static LeafMetadata equalsMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(equals).valueObject(value);
+    public static LeafMetadata equalsMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(equals).valueObject(value);
     }
 
-    public static LeafMetadata equalsMetadata(DslField field, Readable value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(equals).valueReadable(value);
+    public static LeafMetadata equalsMetadata(PredicateMetadata metadata, Readable value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(equals).valueReadable(value);
     }
 
-    public static LeafMetadata equalsMetadata(DslField field, DefaultCondition<?> condition) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(equals).valueCondition(condition);
+    public static LeafMetadata equalsMetadata(PredicateMetadata metadata, DefaultCondition<?> condition) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(equals).valueCondition(condition);
     }
 
-    public static LeafMetadata notEqualsMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(not_equals).valueObject(value);
+    public static LeafMetadata notEqualsMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(not_equals).valueObject(value);
     }
 
-    public static LeafMetadata notEqualsMetadata(DslField field, Readable value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(not_equals).valueReadable(value);
+    public static LeafMetadata notEqualsMetadata(PredicateMetadata metadata, Readable value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(not_equals).valueReadable(value);
     }
 
     // null
 
-    public static LeafMetadata nullMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(is_null);
+    public static LeafMetadata nullMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(is_null);
     }
 
-    public static LeafMetadata notNullMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(is_not_null);
+    public static LeafMetadata notNullMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(is_not_null);
     }
 
     // match
 
-    public static LeafMetadata matchAnyMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE_MATCH_ANY).field(field).operator(match_any).valueUnknown("-function-");
+    public static LeafMetadata matchAnyMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE_MATCH_ANY).operator(match_any).valueUnknown("-function-");
     }
 
-    public static LeafMetadata matchAnyMetadata(DslField field, Collection<?> values) {
-        return new LeafMetadata(FIELD_PREDICATE_MATCH_ANY).field(field).operator(match_any).valueListObject(values);
+    public static LeafMetadata matchAnyMetadata(PredicateMetadata metadata, Collection<?> values) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE_MATCH_ANY).operator(match_any).valueListObject(values);
     }
 
-    public static LeafMetadata matchAllMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(match_all).valueUnknown("-function-");
+    public static LeafMetadata matchAllMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(match_all).valueUnknown("-function-");
     }
 
-    public static LeafMetadata matchAllMetadata(DslField field, Collection<?> values) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(match_all).valueListObject(values);
+    public static LeafMetadata matchAllMetadata(PredicateMetadata metadata, Collection<?> values) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(match_all).valueListObject(values);
     }
 
-    public static LeafMetadata matchNoneMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(match_none).valueUnknown("-function-");
+    public static LeafMetadata matchNoneMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(match_none).valueUnknown("-function-");
     }
 
-    public static LeafMetadata matchNoneMetadata(DslField field, Collection<?> values) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(match_none).valueListObject(values);
+    public static LeafMetadata matchNoneMetadata(PredicateMetadata metadata, Collection<?> values) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(match_none).valueListObject(values);
     }
 
     // map
 
-    public static LeafMetadata mapToIntMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(as_a_number).valueUnknown("");
+    public static LeafMetadata mapToIntMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(as_a_number).valueUnknown("");
     }
 
     // with
 
-    public static LeafMetadata withMetadata(DslField field, Readable adjuster) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(with).valueTemporalAdjuster(adjuster);
+    public static LeafMetadata withMetadata(PredicateMetadata metadata, Readable adjuster) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(with).valueTemporalAdjuster(adjuster);
     }
 
     // minus
 
-    public static LeafMetadata minusMetadata(DslField field, int value, Object unit) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(minus).valueObject(value).temporalUnit(unit);
+    public static LeafMetadata minusMetadata(PredicateMetadata metadata, int value, Object unit) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(minus).valueObject(value).temporalUnit(unit);
     }
 
-    public static LeafMetadata minusMetadata(DslField field1, DslField field2, Object unit) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(minus).field(field2).temporalUnit(unit);
+    public static LeafMetadata minusMetadata(PredicateMetadata metadata, DslField field2, Object unit) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(minus).field(field2).temporalUnit(unit);
     }
 
     // plus
 
-    public static LeafMetadata plusMetadata(DslField field, int value, Object unit) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(plus).valueObject(value).temporalUnit(unit);
+    public static LeafMetadata plusMetadata(PredicateMetadata metadata, int value, Object unit) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(plus).valueObject(value).temporalUnit(unit);
     }
 
-    public static LeafMetadata plusMetadata(DslField field1, DslField field2, Object unit) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(plus).field(field2).temporalUnit(unit);
+    public static LeafMetadata plusMetadata(PredicateMetadata metadata, DslField field2, Object unit) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(plus).field(field2).temporalUnit(unit);
     }
 
     // after
@@ -408,143 +416,139 @@ public class LeafMetadata extends PredicateMetadata {
 
     // string
 
-    public static LeafMetadata matchesMetadata(DslField field, String value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(matches).valueString(value);
+    public static LeafMetadata matchesMetadata(PredicateMetadata metadata, String value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(matches).valueString(value);
     }
 
-    public static LeafMetadata containsMetadata(DslField field, String value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(contains).valueString(value);
+    public static LeafMetadata containsMetadata(PredicateMetadata metadata, String value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(contains).valueString(value);
     }
 
-    public static LeafMetadata startsWithMetadata(DslField field, String value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(starts_with).valueString(value);
+    public static LeafMetadata startsWithMetadata(PredicateMetadata metadata, String value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(starts_with).valueString(value);
     }
 
-    public static LeafMetadata endsWithMetadata(DslField field, String value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(ends_with).valueString(value);
+    public static LeafMetadata endsWithMetadata(PredicateMetadata metadata, String value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(ends_with).valueString(value);
     }
 
     // boolean
 
-    public static LeafMetadata notMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(not);
+    public static LeafMetadata notMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(not);
     }
 
-    public static LeafMetadata andMetadata(DslField field, boolean value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(and).valueObject(value);
+    public static LeafMetadata andMetadata(PredicateMetadata metadata, boolean value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(and).valueObject(value);
     }
 
-    public static LeafMetadata andMetadata(DslField field, Readable value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(and).valueReadable(value);
+    public static LeafMetadata andMetadata(PredicateMetadata metadata, Readable value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(and).valueReadable(value);
     }
 
-    public static LeafMetadata orMetadata(DslField field, boolean value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(or).valueObject(value);
+    public static LeafMetadata orMetadata(PredicateMetadata metadata, boolean value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(or).valueObject(value);
     }
 
-    public static LeafMetadata orMetadata(DslField field, Readable value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(or).valueReadable(value);
+    public static LeafMetadata orMetadata(PredicateMetadata metadata, Readable value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(or).valueReadable(value);
     }
 
-    public static LeafMetadata xorMetadata(DslField field, boolean value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(xor).valueObject(value);
+    public static LeafMetadata xorMetadata(PredicateMetadata metadata, boolean value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(xor).valueObject(value);
     }
 
-    public static LeafMetadata xorMetadata(DslField field, Readable value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(xor).valueReadable(value);
+    public static LeafMetadata xorMetadata(PredicateMetadata metadata, Readable value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(xor).valueReadable(value);
     }
 
     // is
 
-    public static LeafMetadata isMetadata(DslField field, boolean value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(is).valueObject(value);
+    public static LeafMetadata isMetadata(PredicateMetadata metadata, boolean value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(is).valueObject(value);
     }
 
     // lesser
 
-    public static LeafMetadata lesserThanMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(lesser_than).valueObject(value);
+    public static LeafMetadata lesserThanMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(lesser_than).valueObject(value);
     }
 
-    public static LeafMetadata lesserThanMetadata(DslField field1, Readable field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(lesser_than).valueReadable(field2);
+    public static LeafMetadata lesserThanMetadata(PredicateMetadata metadata, Readable field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(lesser_than).valueReadable(field2);
     }
 
-    public static LeafMetadata lesserThanMetadata(DslField field1, DslField field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(lesser_than).field(field2);
+    public static LeafMetadata lesserThanMetadata(PredicateMetadata metadata, DslField field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(lesser_than).field(field2);
     }
 
-    public static LeafMetadata lesserOrEqualsMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(lesser_or_equals).valueObject(value);
+    public static LeafMetadata lesserOrEqualsMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(lesser_or_equals).valueObject(value);
     }
 
-    public static LeafMetadata lesserOrEqualsMetadata(DslField field1, Readable field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(lesser_or_equals).valueReadable(field2);
-    }
-
-    public static LeafMetadata lesserOrEqualsMetadata(DslField field1, DslField field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(lesser_or_equals).field(field2);
+    public static LeafMetadata lesserOrEqualsMetadata(PredicateMetadata metadata, DslField field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(lesser_or_equals).field(field2);
     }
 
     // lesser
 
-    public static LeafMetadata greaterThanMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(greater_than).valueObject(value);
+    public static LeafMetadata greaterThanMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(greater_than).valueObject(value);
     }
 
-    public static LeafMetadata greaterThanMetadata(DslField field1, Readable field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(greater_than).valueReadable(field2);
+    public static LeafMetadata greaterThanMetadata(PredicateMetadata metadata, Readable field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(greater_than).valueReadable(field2);
     }
 
-    public static LeafMetadata greaterThanMetadata(DslField field1, DslField field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(greater_than).field(field2);
+    public static LeafMetadata greaterThanMetadata(PredicateMetadata metadata, DslField field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(greater_than).field(field2);
     }
 
-    public static LeafMetadata greaterOrEqualsMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(greater_or_equals).valueObject(value);
+    public static LeafMetadata greaterOrEqualsMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(greater_or_equals).valueObject(value);
     }
 
-    public static LeafMetadata greaterOrEqualsMetadata(DslField field1, Readable field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(greater_or_equals).valueReadable(field2);
+    public static LeafMetadata greaterOrEqualsMetadata(PredicateMetadata metadata, Readable field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(greater_or_equals).valueReadable(field2);
     }
 
-    public static LeafMetadata greaterOrEqualsMetadata(DslField field1, DslField field2) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field1).operator(greater_or_equals).field(field2);
+    public static LeafMetadata greaterOrEqualsMetadata(PredicateMetadata metadata, DslField field2) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(greater_or_equals).field(field2);
     }
     // length is
 
-    public static LeafMetadata lengthIsMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(length_is);
+    public static LeafMetadata lengthIsMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(length_is);
     }
 
     // length is
 
-    public static LeafMetadata containsMetadata(DslField field, Object value) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(contains).valueObject(value);
+    public static LeafMetadata containsMetadata(PredicateMetadata metadata, Object value) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(contains).valueObject(value);
     }
 
-    public static LeafMetadata containsMetadata(DslField field, Collection<Object> values) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(contains).valueListObject(values);
+    public static LeafMetadata containsMetadata(PredicateMetadata metadata, Collection<Object> values) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(contains).valueListObject(values);
     }
 
     // empty
 
-    public static LeafMetadata isEmptyMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(is_empty);
+    public static LeafMetadata isEmptyMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(is_empty);
     }
 
-    public static LeafMetadata isNotEmptyMetadata(DslField field) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(is_not_empty);
+    public static LeafMetadata isNotEmptyMetadata(PredicateMetadata metadata) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(is_not_empty);
     }
 
     // size
 
-    public static LeafMetadata hasSizeMetadata(DslField field, int size) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(has_size).valueObject(size);
+    public static LeafMetadata hasSizeMetadata(PredicateMetadata metadata, int size) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(has_size).valueObject(size);
     }
 
-    public static LeafMetadata hasNotSizeMetadata(DslField field, int size) {
-        return new LeafMetadata(FIELD_PREDICATE).field(field).operator(has_not_size).valueObject(size);
+    public static LeafMetadata hasNotSizeMetadata(PredicateMetadata metadata, int size) {
+        return new LeafMetadata(metadata, FIELD_PREDICATE).operator(has_not_size).valueObject(size);
     }
 
     // local date suppliers

--- a/core/src/main/java/io/doov/core/dsl/meta/NaryMetadata.java
+++ b/core/src/main/java/io/doov/core/dsl/meta/NaryMetadata.java
@@ -93,10 +93,14 @@ public class NaryMetadata extends PredicateMetadata {
     @Override
     public PredicateMetadata merge(LeafMetadata other) {
         final List<Element> elts = other.stream().collect(Collectors.toList());
-        if (elts.size() == 2 && elts.get(0).getType() == OPERATOR) {
+        if (elts.get(0).getType() == OPERATOR && (
+                elts.get(0).getReadable() == DefaultOperator.sum ||
+                        elts.get(0).getReadable() == DefaultOperator.min ||
+                        elts.get(0).getReadable() == DefaultOperator.count
+        )) {
             // special case to build : count (predicate ...) operator value
-            return new BinaryMetadata(this, (Operator) elts.get(0).getReadable(),
-                            new LeafMetadata(LEAF_PREDICATE).valueReadable(elts.get(1).getReadable()));
+            return new BinaryMetadata(this, (Operator) elts.get(elts.size() - 2).getReadable(),
+                            new LeafMetadata(LEAF_PREDICATE).valueReadable(elts.get(elts.size() - 1).getReadable()));
         }
         return new NaryMetadata(new ComposeOperator(operator, other), values);
     }

--- a/core/src/main/java/io/doov/core/dsl/time/LocalDateSuppliers.java
+++ b/core/src/main/java/io/doov/core/dsl/time/LocalDateSuppliers.java
@@ -91,7 +91,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> today() {
-        return new LocalDateCondition(null, todayMetadata(),
+        return new LocalDateCondition(todayMetadata(),
                         (model, context) -> Optional.of(LocalDate.now(getClock())));
     }
 
@@ -103,7 +103,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> todayPlus(int amountToAdd, TemporalUnit unit) {
-        return new LocalDateCondition(null, todayPlusMetadata(amountToAdd, unit),
+        return new LocalDateCondition(todayPlusMetadata(amountToAdd, unit),
                         (model, context) -> Optional.of(LocalDate.now(getClock()).plus(amountToAdd, unit)));
     }
 
@@ -135,7 +135,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> todayMinus(int amountToSubstract, TemporalUnit unit) {
-        return new LocalDateCondition(null, todayMinusMetadata(amountToSubstract, unit),
+        return new LocalDateCondition(todayMinusMetadata(amountToSubstract, unit),
                         (model, context) -> Optional.of(LocalDate.now(getClock()).minus(amountToSubstract, unit)));
     }
 
@@ -165,7 +165,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> firstDayOfThisMonth() {
-        return new LocalDateCondition(null, firstDayOfThisMonthMetadata(),
+        return new LocalDateCondition(firstDayOfThisMonthMetadata(),
                         (model, context) -> Optional.of(LocalDate.now(getClock()).with(firstDayOfMonth())));
     }
 
@@ -175,7 +175,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> firstDayOfThisYear() {
-        return new LocalDateCondition(null, firstDayOfThisYearMetadata(),
+        return new LocalDateCondition(firstDayOfThisYearMetadata(),
                         (model, context) -> Optional.of(LocalDate.now(getClock()).with(firstDayOfYear())));
     }
 
@@ -185,7 +185,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> lastDayOfThisMonth() {
-        return new LocalDateCondition(null, lastDayOfThisMonthMetadata(),
+        return new LocalDateCondition(lastDayOfThisMonthMetadata(),
                         (model, context) -> Optional.of(LocalDate.now(getClock()).with(lastDayOfMonth())));
     }
 
@@ -195,7 +195,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> lastDayOfThisYear() {
-        return new LocalDateCondition(null, lastDayOfThisYearMetadata(),
+        return new LocalDateCondition(lastDayOfThisYearMetadata(),
                         (model, context) -> Optional.of(LocalDate.now(getClock()).with(lastDayOfYear())));
     }
 
@@ -208,7 +208,7 @@ public class LocalDateSuppliers {
      * @return the temporal condition
      */
     public static TemporalCondition<LocalDate> date(int year, int month, int dayOfMonth) {
-        return new LocalDateCondition(null, dateMetadata(LocalDate.of(year, month, dayOfMonth)),
+        return new LocalDateCondition(dateMetadata(LocalDate.of(year, month, dayOfMonth)),
                         (model, context) -> Optional.of(LocalDate.of(year, month, dayOfMonth)));
     }
 


### PR DESCRIPTION
Before this PR condition implementations were bound to propagate the DslField to build the metadata associated with the condition. 
With this PR the condition metadata is build only using the previous metadata.

This allows creating conditions on top of functions of type (model, context) -> Optional<T>.
Which can use the context, as well as the model.

The code generated strongly-typed FieldInfo's are a special case of this, using the DslField and DslModel to access to the field.

Overall this enables creating strongly-typed DSL extensions creating conditions using inputs other than the DslModel.

