### PR TITLE
Extension of map(...).using() to support lambdas

### DIFF
--- a/core/src/main/java/io/doov/core/dsl/mapping/builder/SimpleStepMap.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/builder/SimpleStepMap.java
@@ -1,9 +1,13 @@
 package io.doov.core.dsl.mapping.builder;
 
+import java.util.Optional;
+import java.util.function.Function;
+
 import io.doov.core.dsl.DslField;
 import io.doov.core.dsl.DslModel;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.mapping.*;
+import io.doov.core.dsl.mapping.converter.DefaultTypeConverter;
 
 /**
  * First step for creating mapping rule.
@@ -31,6 +35,21 @@ public class SimpleStepMap<I> {
      * @return the step mapping
      */
     public <O> SimpleStepMap<O> using(TypeConverter<I, O> typeConverter) {
+        return new SimpleStepMap<>(new ConverterInput<>(input, typeConverter));
+    }
+
+    /**
+     * Return the step mapping
+     *
+     * @param conversionOp conversion operation
+     * @param <O>           out type
+     * @return the step mapping
+     */
+    public <O> SimpleStepMap<O> using(Function<I, O> conversionOp) {
+
+        String repr = conversionOp.getClass().getSimpleName();
+
+        TypeConverter<I,O> typeConverter = TypeConverters.converter(conversionOp,repr);
         return new SimpleStepMap<>(new ConverterInput<>(input, typeConverter));
     }
 

--- a/core/src/test/java/io/doov/core/dsl/mapping/builder/SimpleStepMapTest.java
+++ b/core/src/test/java/io/doov/core/dsl/mapping/builder/SimpleStepMapTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) by Courtanet, All Rights Reserved.
+ */
+package io.doov.core.dsl.mapping.builder;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.doov.core.dsl.DOOV;
+import io.doov.core.dsl.field.types.IntegerFieldInfo;
+import io.doov.core.dsl.field.types.StringFieldInfo;
+import io.doov.core.dsl.lang.MappingRule;
+import io.doov.core.dsl.lang.ValidationRule;
+import io.doov.core.dsl.mapping.TypeConverters;
+import io.doov.core.dsl.runtime.GenericModel;
+
+public class SimpleStepMapTest {
+
+    static GenericModel model = new GenericModel();
+
+    static IntegerFieldInfo input = model.intField(123456, "input");
+    static StringFieldInfo output = model.stringField("", "output");
+
+    @Test
+    public void test_converter_lambda_lift() {
+
+        MappingRule mapping      = DOOV.map(input).using(Object::toString).to(output);
+        ValidationRule validated = DOOV.when(output.eq("123456")).validate();
+
+        mapping.executeOn(model,model);
+
+        Assertions.assertThat(validated.executeOn(model).value()).isEqualTo(true);
+    }
+}


### PR DESCRIPTION
The syntax of 'using' can be tedious when you have to instantiate a one shot type converter.

This proposal aim to reduce the syntactic noise with the use of a lambda function.