### PR TITLE
Deprecated MappingInput, all code in ContextAccessor now

### DIFF
--- a/core/src/main/java/io/doov/core/dsl/DOOV.java
+++ b/core/src/main/java/io/doov/core/dsl/DOOV.java
@@ -24,6 +24,7 @@ import java.util.function.*;
 import java.util.stream.*;
 
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.field.types.NumericFieldInfo;
 import io.doov.core.dsl.impl.*;
 import io.doov.core.dsl.impl.num.IntegerFunction;
@@ -289,7 +290,7 @@ public class DOOV {
      * @param <I>   value type
      * @return value map step
      */
-    public static <I> ContextawareStepMap<I> map(MappingInput<I> input) {
+    public static <I> ContextawareStepMap<I> map(ContextAccessor<I> input) {
         return new ContextawareStepMap<>(input);
     }
 

--- a/core/src/main/java/io/doov/core/dsl/field/types/ContextAccessor.java
+++ b/core/src/main/java/io/doov/core/dsl/field/types/ContextAccessor.java
@@ -19,8 +19,26 @@ import java.util.Optional;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.lang.Context;
+import io.doov.core.dsl.meta.Metadata;
 
 public interface ContextAccessor<T> {
-    
+
+    /**
+     * Verifies the input for given in model
+     *
+     * @param model the model
+     * @param context the context
+     * @return true if the input can read a value from the model
+     */
     Optional<T> value(FieldModel model, Context context);
+
+    /**
+     * Verifies the input for given in model
+     *
+     * @param model in model
+     * @return true if the input can read a value from the model
+     */
+    boolean validate(FieldModel model);
+
+    Metadata metadata();
 }

--- a/core/src/main/java/io/doov/core/dsl/impl/DefaultFunction.java
+++ b/core/src/main/java/io/doov/core/dsl/impl/DefaultFunction.java
@@ -42,6 +42,16 @@ public class DefaultFunction<N, M extends Metadata> implements Function<N> {
         return function.apply(model, context);
     }
 
+    @Override
+    public boolean validate(FieldModel model) {
+        return false;
+    }
+
+    @Override
+    public Metadata metadata() {
+        return null;
+    }
+
     public M getMetadata() {
         return metadata;
     }

--- a/core/src/main/java/io/doov/core/dsl/lang/MappingInput.java
+++ b/core/src/main/java/io/doov/core/dsl/lang/MappingInput.java
@@ -22,6 +22,7 @@ import io.doov.core.FieldModel;
  *
  * @param <T> input value type
  */
+@Deprecated
 public interface MappingInput<T> extends DSLBuilder {
 
     /**

--- a/core/src/main/java/io/doov/core/dsl/mapping/ConverterInput.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/ConverterInput.java
@@ -3,18 +3,21 @@
  */
 package io.doov.core.dsl.mapping;
 
+import java.util.Optional;
+
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingInputMetadata;
 import io.doov.core.dsl.meta.Metadata;
 
-public class ConverterInput<S, T> extends AbstractDSLBuilder implements MappingInput<T> {
+public class ConverterInput<S, T> extends AbstractDSLBuilder implements ContextAccessor<T> {
 
-    private final MappingInput<S> sourceInput;
+    private final ContextAccessor<S> sourceInput;
     private final TypeConverter<S, T> typeConverter;
     private final MappingInputMetadata metadata;
 
-    public ConverterInput(MappingInput<S> sourceInput, TypeConverter<S, T> typeConverter) {
+    public ConverterInput(ContextAccessor<S> sourceInput, TypeConverter<S, T> typeConverter) {
         this.sourceInput = sourceInput;
         this.typeConverter = typeConverter;
         this.metadata = MappingInputMetadata.inputMetadata(sourceInput.metadata(), typeConverter.metadata());
@@ -31,8 +34,8 @@ public class ConverterInput<S, T> extends AbstractDSLBuilder implements MappingI
     }
 
     @Override
-    public T read(FieldModel inModel, Context context) {
-        return typeConverter.convert(inModel, context, sourceInput.read(inModel, context));
+    public Optional<T> value(FieldModel model, Context context) {
+        Optional<S> input = sourceInput.value(model, context);
+        return input.flatMap(s -> Optional.ofNullable(typeConverter.convert(model, context, s)));
     }
-
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/DefaultMappingRule.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/DefaultMappingRule.java
@@ -4,6 +4,7 @@
 package io.doov.core.dsl.mapping;
 
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.impl.DefaultContext;
 import io.doov.core.dsl.impl.ModelInterceptor;
 import io.doov.core.dsl.lang.*;
@@ -12,11 +13,11 @@ import io.doov.core.dsl.meta.Metadata;
 
 public class DefaultMappingRule<T> extends AbstractDSLBuilder implements MappingRule {
 
-    private final MappingInput<T> input;
+    private final ContextAccessor<T> input;
     private final MappingOutput<T> output;
     private final MappingRuleMetadata metadata;
 
-    public DefaultMappingRule(MappingInput<T> input, MappingOutput<T> output) {
+    public DefaultMappingRule(ContextAccessor<T> input, MappingOutput<T> output) {
         this.input = input;
         this.output = output;
         this.metadata = new MappingRuleMetadata(input.metadata(), output.metadata());
@@ -41,7 +42,7 @@ public class DefaultMappingRule<T> extends AbstractDSLBuilder implements Mapping
     public <C extends Context> C executeOn(FieldModel inModel, FieldModel outModel, C context) {
         ModelInterceptor in = new ModelInterceptor(inModel, context);
         ModelInterceptor out = new ModelInterceptor(outModel, context);
-        output.write(out, context, input.read(in, context));
+        output.write(out, context, input.value(in, context).orElse(null));
         return context;
     }
 

--- a/core/src/main/java/io/doov/core/dsl/mapping/FieldInput.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/FieldInput.java
@@ -3,12 +3,15 @@
  */
 package io.doov.core.dsl.mapping;
 
+import java.util.Optional;
+
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 
-public class FieldInput<T> extends AbstractDSLBuilder implements MappingInput<T> {
+public class FieldInput<T> extends AbstractDSLBuilder implements ContextAccessor<T> {
 
     private final MappingMetadata metadata;
     private final DslField<T> field;
@@ -29,7 +32,7 @@ public class FieldInput<T> extends AbstractDSLBuilder implements MappingInput<T>
     }
 
     @Override
-    public T read(FieldModel inModel, Context context) {
-        return inModel.get(field);
+    public Optional<T> value(FieldModel model, Context context) {
+        return Optional.ofNullable(model.get(field));
     }
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/FunctionInput.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/FunctionInput.java
@@ -3,13 +3,15 @@
  */
 package io.doov.core.dsl.mapping;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingMetadata;
 
-public class FunctionInput<T> extends AbstractDSLBuilder implements MappingInput<T> {
+public class FunctionInput<T> extends AbstractDSLBuilder implements ContextAccessor<T> {
 
     private final BiFunction<FieldModel, Context, T> valueFunction;
     private final MappingMetadata metadata;
@@ -34,7 +36,7 @@ public class FunctionInput<T> extends AbstractDSLBuilder implements MappingInput
     }
 
     @Override
-    public T read(FieldModel inModel, Context context) {
-        return valueFunction.apply(inModel, context);
+    public Optional<T> value(FieldModel model, Context context) {
+        return Optional.ofNullable(valueFunction.apply(model, context));
     }
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/NaryConverterInput.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/NaryConverterInput.java
@@ -8,14 +8,16 @@ import static io.doov.core.dsl.meta.MappingMetadata.fieldsInput;
 import static io.doov.core.dsl.meta.MappingMetadata.metadataInput;
 
 import java.util.List;
+import java.util.Optional;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.MappingInputMetadata;
 import io.doov.core.dsl.meta.Metadata;
 
-public class NaryConverterInput<T> extends AbstractDSLBuilder implements MappingInput<T> {
+public class NaryConverterInput<T> extends AbstractDSLBuilder implements ContextAccessor<T> {
 
     private final List<DslField<?>> fields;
     private final NaryTypeConverter<T> converter;
@@ -38,8 +40,8 @@ public class NaryConverterInput<T> extends AbstractDSLBuilder implements Mapping
     }
 
     @Override
-    public T read(FieldModel inModel, Context context) {
-        return converter.convert(inModel, context, fields.toArray(new DslField[0]));
+    public Optional<T> value(FieldModel model, Context context) {
+        return Optional.ofNullable(converter.convert(model, context, fields.toArray(new DslField[0])));
     }
 
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/StaticInput.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/StaticInput.java
@@ -3,13 +3,15 @@
  */
 package io.doov.core.dsl.mapping;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.doov.core.FieldModel;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.meta.StaticMetadata;
 
-public class StaticInput<T> extends AbstractDSLBuilder implements MappingInput<T> {
+public class StaticInput<T> extends AbstractDSLBuilder implements ContextAccessor<T> {
 
     private final Supplier<T> valueSupplier;
     private final StaticMetadata<T> metadata;
@@ -20,7 +22,7 @@ public class StaticInput<T> extends AbstractDSLBuilder implements MappingInput<T
     }
 
     @Override
-    public boolean validate(FieldModel inModel) {
+    public boolean validate(FieldModel model) {
         return true;
     }
 
@@ -30,7 +32,7 @@ public class StaticInput<T> extends AbstractDSLBuilder implements MappingInput<T
     }
 
     @Override
-    public T read(FieldModel inModel, Context context) {
-        return valueSupplier.get();
+    public Optional<T> value(FieldModel model, Context context) {
+        return Optional.ofNullable(valueSupplier.get());
     }
 }

--- a/core/src/main/java/io/doov/core/dsl/mapping/builder/BiStepMap.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/builder/BiStepMap.java
@@ -17,6 +17,7 @@ package io.doov.core.dsl.mapping.builder;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.mapping.*;
 
@@ -58,7 +59,7 @@ public class BiStepMap<I, J> {
      */
     public class BiStepMapping<I, J, O> {
 
-        private final MappingInput<O> input;
+        private final ContextAccessor<O> input;
 
         BiStepMapping(DslField<I> inFieldInfo, DslField<J> in2FieldInfo, BiTypeConverter<I, J, O> typeConverter) {
             this.input = new BiConverterInput<>(

--- a/core/src/main/java/io/doov/core/dsl/mapping/builder/ContextawareStepMap.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/builder/ContextawareStepMap.java
@@ -19,14 +19,15 @@ import java.util.function.BiFunction;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.mapping.*;
 
 public class ContextawareStepMap<I> {
 
-    private MappingInput<I> input;
+    private ContextAccessor<I> input;
 
-    public ContextawareStepMap(MappingInput<I> input) {
+    public ContextawareStepMap(ContextAccessor<I> input) {
         this.input = input;
     }
 

--- a/core/src/main/java/io/doov/core/dsl/mapping/builder/SimpleStepMap.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/builder/SimpleStepMap.java
@@ -17,6 +17,7 @@ package io.doov.core.dsl.mapping.builder;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.mapping.*;
 
@@ -28,9 +29,9 @@ import io.doov.core.dsl.mapping.*;
  */
 public class SimpleStepMap<I> {
 
-    private final MappingInput<I> input;
+    private final ContextAccessor<I> input;
 
-    public SimpleStepMap(MappingInput<I> input) {
+    public SimpleStepMap(ContextAccessor<I> input) {
         this.input = input;
     }
 

--- a/core/src/main/java/io/doov/core/dsl/mapping/builder/StaticStepMap.java
+++ b/core/src/main/java/io/doov/core/dsl/mapping/builder/StaticStepMap.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 
 import io.doov.core.FieldModel;
 import io.doov.core.dsl.DslField;
+import io.doov.core.dsl.field.types.ContextAccessor;
 import io.doov.core.dsl.lang.*;
 import io.doov.core.dsl.mapping.*;
 
@@ -29,13 +30,13 @@ import io.doov.core.dsl.mapping.*;
  */
 public class StaticStepMap<I> {
 
-    private final MappingInput<I> input;
+    private final ContextAccessor<I> input;
 
     public StaticStepMap(Supplier<I> input) {
         this(new StaticInput<>(input));
     }
 
-    private StaticStepMap(MappingInput<I> input) {
+    private StaticStepMap(ContextAccessor<I> input) {
         this.input = input;
     }
 


### PR DESCRIPTION
The two classes MappingInput and ContextAccessor are kind of the same...

With this branch we Deprecated MappingInput and replaced all occurrences with ContextAccessor.